### PR TITLE
SLIP Encoding

### DIFF
--- a/example_compression/src/ofApp.cpp
+++ b/example_compression/src/ofApp.cpp
@@ -102,7 +102,15 @@ void ofApp::setup()
         ofLogNotice("ofApp::test()") << "ofx::IO::COBSEncoding: FAILURE";
     }
 
-
+    ofx::IO::SLIPEncoding slipEncoding;
+    if (test(slipEncoding))
+    {
+        ofLogNotice("ofApp::test()") << "ofx::IO::SLIPEncoding: SUCCESS";
+    }
+    else
+    {
+        ofLogNotice("ofApp::test()") << "ofx::IO::SLIPEncoding: FAILURE";
+    }
 }
 
 

--- a/libs/ofxIO/include/ofx/IO/SLIPEncoding.h
+++ b/libs/ofxIO/include/ofx/IO/SLIPEncoding.h
@@ -1,0 +1,84 @@
+// =============================================================================
+//
+// Copyright (c) 2015 Jean-Pierre Mouilleseaux <jpm@chordedconstructions.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+
+
+#include <stdint.h>
+#include "ByteBuffer.h"
+
+
+namespace ofx {
+namespace IO {
+
+/// \brief A Serial Line IP (SLIP) Encoder.
+///
+/// Serial Line IP (SLIP) is a packet framing protocol: SLIP defines a
+/// sequence of characters that frame IP packets on a serial line, and
+/// nothing more. It provides no addressing, packet type identification,
+/// error detection/correction or compression mechanisms.  Because the
+/// protocol does so little, though, it is usually very easy to
+/// implement.
+///
+/// \sa http://tools.ietf.org/html/rfc1055
+class SLIPEncoding: public AbstractByteEncoderDecoder
+{
+public:
+    /// \brief Create a SLIPEncoding.
+    SLIPEncoding();
+
+    /// \brief Destroy a SLIPEncoding.
+    virtual ~SLIPEncoding();
+
+    bool encode(const AbstractByteSource& buffer,
+                AbstractByteSink& encodedBuffer);
+
+    bool decode(const AbstractByteSource& buffer,
+                AbstractByteSink& decodedBuffer);
+
+    /// \brief Encode a byte buffer with the SLIP encoder.
+    /// \param buffer The buffer to encode.
+    /// \param size The size of the buffer to encode.
+    /// \param encodedBuffer The target buffer for the encoded bytes.
+    /// \returns The number of bytes in the encoded buffer.
+    /// \warning encodedBuffer must have a minimum capacity of
+    ///     (size + 1).
+    static std::size_t encode(const uint8_t* buffer,
+                              std::size_t size,
+                              uint8_t* encodedBuffer);
+
+
+    /// \brief Decode a SLIP-encoded buffer.
+    /// \param buffer The SLIP-encoded buffer to decode.
+    /// \param size The size of the SLIP-encoded buffer.
+    /// \param decodedBuffer The target buffer for the decoded bytes.
+    /// \returns The number of bytes in the decoded buffer.
+    /// \warning decodedBuffer must have a minimum capacity of
+    ///     size.
+    static std::size_t decode(const uint8_t* buffer,
+                              std::size_t size,
+                              uint8_t* decodedBuffer);
+
+};
+
+
+} } // namespace ofx::IO

--- a/libs/ofxIO/src/SLIPEncoding.cpp
+++ b/libs/ofxIO/src/SLIPEncoding.cpp
@@ -1,0 +1,158 @@
+// =============================================================================
+//
+// Copyright (c) 2015 Jean-Pierre Mouilleseaux <jpm@chordedconstructions.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+// =============================================================================
+
+
+#include "ofx/IO/SLIPEncoding.h"
+#include "Poco/Buffer.h"
+
+
+namespace ofx {
+namespace IO {
+
+
+static const uint8_t END = 0300;
+static const uint8_t ESC = 0333;
+static const uint8_t ESC_END = 0334;
+static const uint8_t ESC_ESC = 0335;
+
+
+SLIPEncoding::SLIPEncoding()
+{
+}
+
+
+SLIPEncoding::~SLIPEncoding()
+{
+}
+
+
+bool SLIPEncoding::encode(const AbstractByteSource& buffer,
+                          AbstractByteSink& encodedBuffer)
+{
+    std::vector<uint8_t> bytes = buffer.readBytes();
+
+    const std::size_t encodedMax = 2 * bytes.size() + 1;
+
+    Poco::Buffer<uint8_t> encoded(encodedMax);
+
+    std::size_t size = encode(&bytes[0], bytes.size(), encoded.begin());
+
+    encodedBuffer.writeBytes(encoded.begin(), size);
+
+    return true;
+}
+
+
+bool SLIPEncoding::decode(const AbstractByteSource& buffer,
+                          AbstractByteSink& decodedBuffer)
+{
+    std::vector<uint8_t> bytes = buffer.readBytes();
+
+    Poco::Buffer<uint8_t> decoded(bytes.size());
+
+    std::size_t size = decode(&bytes[0], bytes.size(), decoded.begin());
+
+    decodedBuffer.writeBytes(decoded.begin(), size);
+
+    return true;
+}
+
+
+std::size_t SLIPEncoding::encode(const uint8_t* buffer,
+                                 std::size_t size,
+                                 uint8_t* encoded)
+{
+    std::size_t read_index  = 0;
+    std::size_t write_index = 0;
+
+    // flush any data that may have accumulated due to line noise
+    encoded[write_index++] = END;
+
+    while (read_index < size)
+    {
+        if(buffer[read_index] == END)
+        {
+            encoded[write_index++] = ESC;
+            encoded[write_index++] = ESC_END;
+            read_index++;
+        }
+        else if(buffer[read_index] == ESC)
+        {
+            encoded[write_index++] = ESC;
+            encoded[write_index++] = ESC_ESC;
+            read_index++;
+        }
+        else
+        {
+            encoded[write_index++] = buffer[read_index++];
+        }
+    }
+
+    encoded[write_index++] = END;
+
+    return write_index;
+}
+
+std::size_t SLIPEncoding::decode(const uint8_t* buffer,
+                                 std::size_t size,
+                                 uint8_t* decoded)
+{
+    std::size_t read_index  = 0;
+    std::size_t write_index = 0;
+
+    while (read_index < size)
+    {
+        if(buffer[read_index] == END)
+        {
+            // flush or done
+            read_index++;
+        }
+        else if(buffer[read_index] == ESC)
+        {
+            if(buffer[read_index+1] == ESC_END)
+            {
+                decoded[write_index++] = END;
+                read_index += 2;
+            }
+            else if(buffer[read_index+1] == ESC_ESC)
+            {
+                decoded[write_index++] = ESC;
+                read_index += 2;
+            }
+            else
+            {
+                // considered a protocol violation
+            }
+        }
+        else
+        {
+            decoded[write_index++] = buffer[read_index++];
+        }
+    }
+
+    return write_index;
+}
+
+
+} }  // namespace ofx::IO

--- a/src/ofxIO.h
+++ b/src/ofxIO.h
@@ -1,6 +1,6 @@
 // =============================================================================
 //
-// Copyright (c) 2010-2013 Christopher Baker <http://christopherbaker.net>
+// Copyright (c) 2010-2015 Christopher Baker <http://christopherbaker.net>
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -46,6 +46,7 @@
 #include "ofx/IO/ByteBufferUtils.h"
 #include "ofx/IO/ByteBufferWriter.h"
 #include "ofx/IO/COBSEncoding.h"
+#include "ofx/IO/SLIPEncoding.h"
 #include "ofx/IO/Compression.h"
 #include "ofx/IO/DeviceFilter.h"
 #include "ofx/IO/DirectoryUtils.h"


### PR DESCRIPTION
With `COBSEncoding` as the template, implement a SLIP encoding following [RFC 1055](http://tools.ietf.org/html/rfc1055). This is not super well tested, I just ran it against a handful of hand-crafted tests to check escape sequences handling and in each case compared the encoded results to another SLIP library ([slip.js](https://github.com/colinbdclark/slip.js)).