### PR TITLE
Fix minimum buffer capacity comment for SLIP encode/decode

### DIFF
--- a/libs/ofxIO/include/ofx/IO/SLIPEncoding.h
+++ b/libs/ofxIO/include/ofx/IO/SLIPEncoding.h
@@ -61,7 +61,7 @@ public:
     /// \param encodedBuffer The target buffer for the encoded bytes.
     /// \returns The number of bytes in the encoded buffer.
     /// \warning encodedBuffer must have a minimum capacity of
-    ///     (size + 1).
+    ///     (2 * size + 2).
     static std::size_t encode(const uint8_t* buffer,
                               std::size_t size,
                               uint8_t* encodedBuffer);
@@ -73,7 +73,7 @@ public:
     /// \param decodedBuffer The target buffer for the decoded bytes.
     /// \returns The number of bytes in the decoded buffer.
     /// \warning decodedBuffer must have a minimum capacity of
-    ///     size.
+    ///     (size - 1).
     static std::size_t decode(const uint8_t* buffer,
                               std::size_t size,
                               uint8_t* decodedBuffer);

--- a/libs/ofxIO/src/SLIPEncoding.cpp
+++ b/libs/ofxIO/src/SLIPEncoding.cpp
@@ -52,7 +52,7 @@ bool SLIPEncoding::encode(const AbstractByteSource& buffer,
 {
     std::vector<uint8_t> bytes = buffer.readBytes();
 
-    const std::size_t encodedMax = 2 * bytes.size() + 1;
+    const std::size_t encodedMax = 2 * bytes.size() + 2;
 
     Poco::Buffer<uint8_t> encoded(encodedMax);
 
@@ -69,7 +69,7 @@ bool SLIPEncoding::decode(const AbstractByteSource& buffer,
 {
     std::vector<uint8_t> bytes = buffer.readBytes();
 
-    Poco::Buffer<uint8_t> decoded(bytes.size());
+    Poco::Buffer<uint8_t> decoded(bytes.size() - 1);
 
     std::size_t size = decode(&bytes[0], bytes.size(), decoded.begin());
 
@@ -86,7 +86,7 @@ std::size_t SLIPEncoding::encode(const uint8_t* buffer,
     std::size_t read_index  = 0;
     std::size_t write_index = 0;
 
-    // flush any data that may have accumulated due to line noise
+    // double-ENDed, flush any data that may have accumulated due to line noise
     encoded[write_index++] = END;
 
     while (read_index < size)


### PR DESCRIPTION
Oups, the minimum capacities comments were incorrect! On encode, assume all content needs escaping plus the two `END` markers and on decode, assume none of the content includes escapes and only a single terminating `END`.