### PR TITLE
Changed depreciated calls to be c++17 compliant

### DIFF
--- a/libs/ofxIO/include/ofx/IO/ThreadsafeLoggerChannel.h
+++ b/libs/ofxIO/include/ofx/IO/ThreadsafeLoggerChannel.h
@@ -66,11 +66,11 @@ public:
 
     virtual void log(ofLogLevel level,
                      const std::string& module,
-                     const char* format, ...) override OF_PRINTF_ATTR(4, 5);
+                     const char* format, ...)  OF_PRINTF_ATTR(4, 5);
 
     virtual void log(ofLogLevel level,
                      const std::string& module,
-                     const char* format, std::va_list args) override;
+                     const char* format, std::va_list args) ;
 
     /// \brief Set the poll interval in milliseconds.
     /// \param interval The poll interval in milliseconds.

--- a/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorImpl.h
+++ b/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorImpl.h
@@ -146,16 +146,15 @@ namespace ofx {
     //
     // not inlines
     //
-    template <class TTraverseStrategy>
-    RecursiveDirectoryIteratorImpl<TTraverseStrategy>
-    ::RecursiveDirectoryIteratorImpl(const std::string& path, Poco::UInt16 maxDepth)
-	: _maxDepth(maxDepth),
-	_traverseStrategy(std::ptr_fun(depthFun), _maxDepth),
-	_isFinished(false)
-    {
-        _itStack.push(Poco::DirectoryIterator(path));
-        _current = _itStack.top()->path();
-    }
+template <class TTraverseStrategy>
+RecursiveDirectoryIteratorImpl<TTraverseStrategy>::RecursiveDirectoryIteratorImpl(const std::string& path, Poco::UInt16 maxDepth)
+    : _maxDepth(maxDepth),
+      _traverseStrategy(depthFun, _maxDepth),
+      _isFinished(false)
+{
+    _itStack.push(Poco::DirectoryIterator(path));
+    _current = _itStack.top()->path();
+}
     
     
     template <class TTraverseStrategy>

--- a/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorStategies.h
+++ b/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorStategies.h
@@ -55,7 +55,7 @@ namespace ofx {
     {
     public:
         typedef std::stack<Poco::DirectoryIterator> Stack;
-        typedef std::pointer_to_unary_function<const Stack&, Poco::UInt16> DepthFunPtr;
+        using DepthFunPtr = std::function<Poco::UInt16(const Stack&)>;
 
         enum { D_INFINITE = 0 };
         /// Constant for infinite traverse depth.

--- a/libs/ofxIO/src/JSONUtils.cpp
+++ b/libs/ofxIO/src/JSONUtils.cpp
@@ -25,7 +25,7 @@ bool JSONUtils::saveJSON(const std::filesystem::path& filename,
         std::ofstream ostr(ofToDataPath(filename.string(), true),
                            std::ios::binary);
 
-        if (std::filesystem::extension(filename) == ".gz")
+        if (filename.extension() == ".gz")
         {
             Poco::DeflatingOutputStream deflater(ostr,
                                                  Poco::DeflatingStreamBuf::STREAM_GZIP);
@@ -66,7 +66,7 @@ bool JSONUtils::loadJSON(const std::filesystem::path& filename,
         std::ifstream istr(ofToDataPath(filename.string(), true),
                            std::ios::binary);
 
-        if (std::filesystem::extension(filename) == ".gz")
+        if (filename.extension() == ".gz")
         {
             Poco::InflatingInputStream inflater(istr, Poco::InflatingStreamBuf::STREAM_GZIP);
             inflater >> json;
@@ -105,9 +105,9 @@ bool JSONUtils::saveCBOR(const std::filesystem::path& filename,
     ByteBuffer cbor(nlohmann::json::to_cbor(json));
     ByteBuffer out;
 
-    if (std::filesystem::extension(filename) == ".gz")
+    if (filename.extension() == ".gz")
         Compression::compress(cbor, out, Compression::GZIP);
-    else if (std::filesystem::extension(filename) == ".br")
+    else if (filename.extension() == ".br")
         Compression::compress(cbor, out, Compression::BR);
     else
         out = cbor;
@@ -123,9 +123,9 @@ bool JSONUtils::loadCBOR(const std::filesystem::path& filename,
     ByteBuffer cbor;
     ByteBufferUtils::loadFromFile(filename.string(), bytes);
 
-    if (std::filesystem::extension(filename) == ".gz")
+    if (filename.extension() == ".gz")
         Compression::uncompress(bytes, cbor, Compression::GZIP);
-    else if (std::filesystem::extension(filename) == ".br")
+    else if (filename.extension() == ".br")
         Compression::uncompress(bytes, cbor, Compression::BR);
     else
         cbor = bytes;


### PR DESCRIPTION
I made the required changes to this addon to be c++17 compliant. As it is a requirement for some of your other great work this is quite helpful. Most of it was easy, and I changed only things that were broken (switched a `typdef` to a `using` in [RecursiveDirectoryIteratorStategies.h](https://github.com/bakercp/ofxIO/compare/develop...fred-dev:ofxIO:develop?expand=1#diff-b6390ae5fea0a4ecd87460cfd81f7a395ed944f41e34ec5a0e8003000a03effc)), however I was unsure about of the OF log overrides so just removed the override. 