### PR TITLE
Modifications to support C++17

### DIFF
--- a/libs/alphanum/include/alphanum.hpp
+++ b/libs/alphanum/include/alphanum.hpp
@@ -305,7 +305,7 @@ namespace doj
      implement "std::ostream operator<< (std::ostream&, const Ty&)".
      */
     template<class Ty>
-    struct alphanum_less : public std::binary_function<Ty, Ty, bool>
+    struct alphanum_less : public std::__binary_function<Ty, Ty, bool>
     {
         bool operator()(const Ty& left, const Ty& right) const
         {

--- a/libs/ofxIO/include/ofx/IO/ThreadsafeLoggerChannel.h
+++ b/libs/ofxIO/include/ofx/IO/ThreadsafeLoggerChannel.h
@@ -62,15 +62,15 @@ public:
 
     virtual void log(ofLogLevel level,
                      const std::string& module,
-                     const std::string & message) override;
+                     const std::string & message);
 
     virtual void log(ofLogLevel level,
                      const std::string& module,
-                     const char* format, ...) override OF_PRINTF_ATTR(4, 5);
+                     const char* format, ...) OF_PRINTF_ATTR(4, 5);
 
     virtual void log(ofLogLevel level,
                      const std::string& module,
-                     const char* format, std::va_list args) override;
+                     const char* format, std::va_list args);
 
     /// \brief Set the poll interval in milliseconds.
     /// \param interval The poll interval in milliseconds.

--- a/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorImpl.h
+++ b/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorImpl.h
@@ -150,7 +150,7 @@ namespace ofx {
     RecursiveDirectoryIteratorImpl<TTraverseStrategy>
     ::RecursiveDirectoryIteratorImpl(const std::string& path, Poco::UInt16 maxDepth)
 	: _maxDepth(maxDepth),
-	_traverseStrategy(std::ptr_fun(depthFun), _maxDepth),
+_traverseStrategy([this](const Stack& stack) { return depthFun(stack); }, _maxDepth),
 	_isFinished(false)
     {
         _itStack.push(Poco::DirectoryIterator(path));

--- a/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorImpl.h
+++ b/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorImpl.h
@@ -150,7 +150,7 @@ namespace ofx {
     RecursiveDirectoryIteratorImpl<TTraverseStrategy>
     ::RecursiveDirectoryIteratorImpl(const std::string& path, Poco::UInt16 maxDepth)
 	: _maxDepth(maxDepth),
-_traverseStrategy([this](const Stack& stack) { return depthFun(stack); }, _maxDepth),
+_traverseStrategy([](const Stack& stack) { return depthFun(stack); }, _maxDepth),
 	_isFinished(false)
     {
         _itStack.push(Poco::DirectoryIterator(path));

--- a/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorStategies.h
+++ b/libs/ofxIO/include/ofx/RecursiveDirectoryIteratorStategies.h
@@ -55,7 +55,7 @@ namespace ofx {
     {
     public:
         typedef std::stack<Poco::DirectoryIterator> Stack;
-        typedef std::pointer_to_unary_function<const Stack&, Poco::UInt16> DepthFunPtr;
+        typedef std::function<Poco::UInt16(const Stack&)> DepthFunPtr;
 
         enum { D_INFINITE = 0 };
         /// Constant for infinite traverse depth.

--- a/libs/ofxIO/src/ImageUtils.cpp
+++ b/libs/ofxIO/src/ImageUtils.cpp
@@ -8,6 +8,7 @@
 #include "ofx/IO/ImageUtils.h"
 #include "FreeImage.h"
 #include "ofRectangle.h"
+#include "ofMain.h"
 
 
 namespace ofx {

--- a/libs/ofxIO/src/JSONUtils.cpp
+++ b/libs/ofxIO/src/JSONUtils.cpp
@@ -23,7 +23,7 @@ bool JSONUtils::saveJSON(const std::filesystem::path& filename,
         std::ofstream ostr(ofToDataPath(filename.string(), true),
                            std::ios::binary);
 
-        if (std::filesystem::extension(filename) == ".gz")
+        if (std::filesystem::path(filename).extension() == ".gz")
         {
             Poco::DeflatingOutputStream deflater(ostr,
                                                  Poco::DeflatingStreamBuf::STREAM_GZIP);
@@ -63,7 +63,7 @@ bool JSONUtils::loadJSON(const std::filesystem::path& filename, ofJson& json)
         std::ifstream istr(ofToDataPath(filename.string(), true),
                            std::ios::binary);
 
-        if (std::filesystem::extension(filename) == ".gz")
+        if (std::filesystem::path(filename).extension() == ".gz")
         {
             Poco::InflatingInputStream inflater(istr, Poco::InflatingStreamBuf::STREAM_GZIP);
             inflater >> json;


### PR DESCRIPTION
Related to #30 #31. Modified some syntaxes that are not compatible with C++17 and things that are throwing error. Tested with oF `0.12.0`.

> [!NOTE]
> I am not an advanced C++ user, and as a matter of fact, I am not completely sure what this change means. It is just a  edit to run examples of `ofxHTTP` with oF `0.12.0` and maybe not complete. I wasn't sure if I should make this Pull Request, but I'm submitting it in case it helps anyone. Of course reviews and change requests are also welcome.